### PR TITLE
test(py): add package-level fixtures and import tests

### DIFF
--- a/bootcamp_python/tests/conftest.py
+++ b/bootcamp_python/tests/conftest.py
@@ -1,0 +1,17 @@
+# -------------------------------------------------------
+# conftest.py
+# PURPOSE: Fixtures available to all test files.
+# Demonstrates yield-fixtures (setup + teardown).
+# -------------------------------------------------------
+import pytest
+from pathlib import Path
+import tempfile
+import shutil
+
+@pytest.fixture(scope="session")
+def temp_data_dir():
+    """Create a temp data directory for all tests in the session."""
+    path = Path(tempfile.mkdtemp(prefix="bootcamp_pydata_"))
+    yield path
+    # teardown runs after tests finish
+    shutil.rmtree(path)

--- a/bootcamp_python/tests/test_cli_imports.py
+++ b/bootcamp_python/tests/test_cli_imports.py
@@ -1,0 +1,10 @@
+# -------------------------------------------------------
+# test_cli_imports.py
+# PURPOSE: Verify the CLI entrypoint imports cleanly.
+# -------------------------------------------------------
+import importlib
+
+def test_cli_imports():
+    module = importlib.import_module("bootcamp_python.cli.tasks_cli")
+    assert hasattr(module, "build_parser")
+

--- a/bootcamp_python/tests/test_models_package.py
+++ b/bootcamp_python/tests/test_models_package.py
@@ -1,0 +1,12 @@
+# -------------------------------------------------------
+# test_models_package.py
+# PURPOSE: Show using a session-scoped fixture across files.
+# -------------------------------------------------------
+from bootcamp_python.models.task import Task
+
+def test_task_to_dict_and_back(temp_data_dir):
+    t = Task("Pkg test")
+    d = t.to_dict()
+    assert d["title"] == "Pkg test"
+    assert d["is_done"] is False
+    # here we could save to temp_data_dir if needed


### PR DESCRIPTION
## Description

Added conftest.py with a session-scoped temp_data_dir fixture to share setup/teardown across test files.

Added test_models_package.py to use the shared fixture and validate task model behavior.

Added test_cli_imports.py to check that CLI modules can be imported without errors.

## Related Issue

N/A

## How to Test

navigate to \BootCamp-Python and run python -m pytest

## Screenshots (if UI-related)



## Checklist

- [x ] Code builds without errors
- [x ] Tests added or updated
- [ x] All tests passing locally
- [ ] Screenshots included if UI changes
